### PR TITLE
fix class scope for command line php7

### DIFF
--- a/lib/ShortPixel.php
+++ b/lib/ShortPixel.php
@@ -201,7 +201,7 @@ function folderInfo($path, $recurse = true, $fileList = false, $exclude = array(
  * @return Commander - the class that handles the optimization commands
  * @throws ClientException
  */
-function fromFolder($path, $maxFiles = self::MAX_ALLOWED_FILES_PER_CALL, $exclude = array()) {
+function fromFolder($path, $maxFiles = ShortPixel::MAX_ALLOWED_FILES_PER_CALL, $exclude = array()) {
     $source = new Source();
     return $source->fromFolder($path, $maxFiles, $exclude);
 }


### PR DESCRIPTION
fixes

```
PHP Fatal error:  Uncaught Error: Cannot access self:: when no class scope is active in ../shortpixel-php/lib/ShortPixel.php:204
Stack trace:
#0 ../shortpixel-php/lib/cmdShortpixelOptimize.php(122): ShortPixel\fromFolder('...')
#1 {main}
  thrown in ../shortpixel-php/lib/ShortPixel.php on line 204

```