### PR TITLE
Fixed Pathing issue

### DIFF
--- a/bin/shortpixel
+++ b/bin/shortpixel
@@ -1,0 +1,2 @@
+#!/bin/bash
+php ../lib/cmdShortpixelOptimize.php $@

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "api"
   ],
 
-  "bin": ["lib/shortpixel"],
+  "bin": ["bin/shortpixel"],
 
   "homepage": "https://shortpixel.com/api",
   "license": "MIT",

--- a/lib/shortpixel
+++ b/lib/shortpixel
@@ -1,2 +1,0 @@
-#!/bin/bash
-php cmdShortpixelOptimize.php $@


### PR DESCRIPTION
You can't have a folder and a file as the same name, I've moved the short pixel executable into /bin instead of /lib

Closes #28 
Closes #26 
Closes #25 